### PR TITLE
Use view URL for jenkins command

### DIFF
--- a/src/main/java/me/nickrobson/skype/superchat/cmd/JenkinsCommand.java
+++ b/src/main/java/me/nickrobson/skype/superchat/cmd/JenkinsCommand.java
@@ -19,7 +19,7 @@ public class JenkinsCommand implements Command {
 
     @Override
     public void exec(SkypeUser user, SkypeConversation group, String used, String[] args, SkypeMessage message) {
-        group.sendMessage(new MessageBuilder().link("http://ci.nickr.xyz/job/SuperChat/").text("Click here for the Jenkins").link(null).build());
+        group.sendMessage(new MessageBuilder().link("http://ci.nickr.xyz/view/SuperChat/").text("Click here for the Jenkins").link(null).build());
     }
 
 }


### PR DESCRIPTION
This changes the ~jenkins command to use the view URL instead of the job URL.
